### PR TITLE
バグ修正(GHA)

### DIFF
--- a/.github/workflows/deploy_to_googlecloud.yml
+++ b/.github/workflows/deploy_to_googlecloud.yml
@@ -79,8 +79,8 @@ jobs:
 
                   # すべてのタグを取得し、最新5つを除外したものを削除
                   gcloud artifacts docker images list ${IMAGE_NAME} --format="value(DIGEST)" --sort-by="~UPDATE_TIME" | tail -n +6 | while read -r DIGEST; do
-                      if [[ ! -z "$DIGEST" ]]; then
+                      if [[ ! -z "${DIGEST}" ]]; then
                           echo "Deleting old image: ${IMAGE_NAME}:${DIGEST}"
-                          gcloud artifacts docker images delete ${IMAGE_NAME}:${DIGEST} --quiet --delete-tags
+                          gcloud artifacts docker images delete "$IMAGE_NAME@$DIGEST" --quiet
                       fi
                   done


### PR DESCRIPTION
今回の GCR のイメージにはタグが付いていない（SHA256 で管理） ため、
--delete-tags を指定すると NOT_FOUND になる可能性あり。
-> --delete-tags を削除して試す。