### PR TITLE
fix: auth check の404を401に変換

### DIFF
--- a/src/app/api/auth/check/route.ts
+++ b/src/app/api/auth/check/route.ts
@@ -1,6 +1,13 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
 export async function GET(req: NextRequest) {
-    return proxyToBackend(req, '/users/auth-check');
+    const res = await proxyToBackend(req, '/users/auth-check');
+
+    // バックエンドが未認証時に404を返す場合、401に変換
+    if (res.status === 404) {
+        return NextResponse.json(null, { status: 401 });
+    }
+
+    return res;
 }


### PR DESCRIPTION
## Summary

- バックエンドが未認証時に404を返すため、ブラウザのDevToolsに404エラーが表示されていた
- auth checkのRoute Handlerで404→401に変換し、セマンティクスを正しくする

## Test plan

- [x] `npm run build` 成功
- [ ] デプロイ後にDevToolsで404エラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)