### PR TITLE
fix(docker): Dockerfile の pnpm を 10.33.0 に固定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,13 @@ FROM node:20 AS builder
 
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# pnpm はバージョン固定（pnpm@latest は Node 22+ 要求の 11.x を引き、node:20 ベースで
+# ERR_UNKNOWN_BUILTIN_MODULE(node:sqlite) クラッシュするため）。CI(test.yml)と同じ 10.33.0 に揃える。
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
-COPY package.json pnpm-lock.yaml ./
+# pnpm-workspace.yaml の onlyBuiltDependencies を install 時に効かせるため一緒に COPY する
+# （未COPY だと sharp / unrs-resolver のビルドが ERR_PNPM_IGNORED_BUILDS で失敗する）
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY . .

--- a/README.md
+++ b/README.md
@@ -24,15 +24,6 @@ GitHub 上で管理している Markdown 記事を読み込んで公開する技
 
 > **未実装（既知）**: 新規登録（`/register`）は UI のみのスタブ、コメント返信は型定義（`parent_id`）のみ。詳細は [docs/11-tasks.md](./docs/11-tasks.md) を参照。
 
-## スクリーンショット
-
-> 📸 スクリーンショットは準備中です。実際の画面は公開サイト https://techblogkk.com で確認できます。
-
-<!-- 画像を追加する場合は docs/images/ に配置し、以下のように参照してください:
-![ホーム画面](./docs/images/home.png)
-![記事詳細](./docs/images/blog-detail.png)
--->
-
 ## 技術スタック
 
 **Frontend**


### PR DESCRIPTION
## 背景
PR #68 マージ後の `Deploy to Cloud Run`（main）が **Docker ビルド段階**で失敗。
`corepack prepare pnpm@latest` が **pnpm 11.5.3（Node.js 22.13+ 要求）** を取得し、`node:20` ベースイメージ上で `ERR_UNKNOWN_BUILTIN_MODULE: No such built-in module: node:sqlite` によりクラッシュしていた。

> 既存の潜在バグ（Dockerfile が `pnpm@latest` を使用）が pnpm 11.5.3 リリースで発火したもの。PR #68 のコード変更が原因ではない。

## 変更
**Docker ビルド修正（本命）**
- `corepack prepare pnpm@latest` → **`pnpm@10.33.0`**（CI `test.yml` と同一・Node 20 互換）
- `pnpm install` 前に **`pnpm-workspace.yaml` を COPY** し `onlyBuiltDependencies` を有効化（`sharp` / `unrs-resolver` の `ERR_PNPM_IGNORED_BUILDS` を防止）

**ついでの docs 変更**
- README からスクリーンショットのプレースホルダ節を削除

## Test plan
- [ ] このPRの `Pull Request Test`（unit + e2e）が green（※Docker ビルドは PR CI に含まれないため、ここでは検証されない）
- [ ] **マージ後の `Deploy to Cloud Run` で Docker ビルド → Cloud Run デプロイが成功すること**（本修正の本命検証）

> ⚠️ ローカルで Docker デーモンが起動できず事前のイメージビルド検証は未実施。ロジックはローカルのフレッシュ `pnpm install --frozen-lockfile`（pnpm 10.33.0 + pnpm-workspace.yaml、EXIT 0）で再現確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)