### PR TITLE
fix(github-markdown): トークン失効時の無認証フォールバックで Zenn 記事本文の表示を復旧

### DIFF
--- a/src/app/api/github/markdown/__tests__/route.test.ts
+++ b/src/app/api/github/markdown/__tests__/route.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { POST } from '../route';
+import type { NextRequest } from 'next/server';
+
+/**
+ * GitHub Markdown プロキシのルートハンドラ。
+ * 外部 I/O は global.fetch（GitHub API）と環境変数のみ。fetch のみモックする。
+ */
+const makeReq = (body: unknown): NextRequest =>
+    ({
+        json: async () => {
+            if (body === undefined) throw new Error('invalid json');
+            return body;
+        },
+    }) as unknown as NextRequest;
+
+// fetch のレスポンスを作る
+const fetchResult = (status: number, text: string) => ({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => text,
+});
+
+const VALID_URL = 'https://github.com/kojikawazu/zenn-article-kk/blob/main/articles/39-x.md';
+const MD = '---\ntitle: x\n---\n# 本文\nzenn記事の本文';
+
+describe('POST /api/github/markdown', () => {
+    beforeEach(() => {
+        vi.stubEnv('GITHUB_TOKEN', 'ghp_validlooking');
+        vi.stubEnv('ALLOWED_REPO_OWNER', 'kojikawazu');
+    });
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.restoreAllMocks();
+    });
+
+    // --- 正常系 ---
+
+    it('トークンが有効ならフロントマターを除去した本文を返す', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(fetchResult(200, MD));
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        const res = await POST(makeReq({ url: VALID_URL }));
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json.content).toContain('zenn記事の本文');
+        expect(json.content).not.toContain('title: x'); // フロントマター除去
+        // 1回目から Authorization 付きで呼ばれる
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const headers = fetchMock.mock.calls[0][1].headers;
+        expect(headers.Authorization).toBe('Bearer ghp_validlooking');
+    });
+
+    it('トークンが401でも無認証フォールバックで再取得して本文を返す', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(fetchResult(401, 'Bad credentials'))
+            .mockResolvedValueOnce(fetchResult(200, MD));
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        const res = await POST(makeReq({ url: VALID_URL }));
+        const json = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(json.content).toContain('zenn記事の本文');
+        // 2回呼ばれ、2回目は Authorization なし
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock.mock.calls[1][1].headers.Authorization).toBeUndefined();
+    });
+
+    // --- 準正常系（想定内の異常入力） ---
+
+    it('許可外オーナーのURLは403を返す（fetchを呼ばない）', async () => {
+        const fetchMock = vi.fn();
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        const res = await POST(
+            makeReq({ url: 'https://github.com/someoneelse/repo/blob/main/a.md' }),
+        );
+
+        expect(res.status).toBe(403);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('URL形式が不正なら400を返す', async () => {
+        const res = await POST(makeReq({ url: 'https://zenn.dev/kojikawazu/articles/abc' }));
+        expect(res.status).toBe(400);
+    });
+
+    it('url フィールドが無ければ400を返す', async () => {
+        const res = await POST(makeReq({ noturl: 1 }));
+        expect(res.status).toBe(400);
+    });
+
+    // --- 異常系 ---
+
+    it('トークンあり・401フォールバックも失敗ならそのステータスでエラーを返す', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(fetchResult(401, 'Bad credentials'))
+            .mockResolvedValueOnce(fetchResult(404, 'Not Found'));
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        const res = await POST(makeReq({ url: VALID_URL }));
+        const json = await res.json();
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(res.status).toBe(404);
+        expect(json.error).toBe('Failed to fetch Markdown content from GitHub');
+    });
+
+    it('JSONボディが不正なら400を返す', async () => {
+        const res = await POST(makeReq(undefined));
+        expect(res.status).toBe(400);
+    });
+});

--- a/src/app/api/github/markdown/route.ts
+++ b/src/app/api/github/markdown/route.ts
@@ -53,12 +53,22 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: 'Repository owner not allowed' }, { status: 403 });
     }
     const apiUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
-    const headers: HeadersInit = {
+    const baseHeaders: HeadersInit = {
         Accept: 'application/vnd.github.v3.raw',
-        ...(githubToken ? { Authorization: `Bearer ${githubToken}` } : {}),
     };
 
-    const response = await fetch(apiUrl, { headers });
+    // トークンがあれば付与して取得
+    let response = await fetch(apiUrl, {
+        headers: githubToken
+            ? { ...baseHeaders, Authorization: `Bearer ${githubToken}` }
+            : baseHeaders,
+    });
+
+    // トークンが失効・権限切れ（401/403）の場合、公開リポジトリ向けに無認証で再取得する。
+    // オーナーは ALLOWED_REPO_OWNER で制限済みのため、無認証で読めるのは公開リポのみ＝private 漏洩リスクはない。
+    if (githubToken && (response.status === 401 || response.status === 403)) {
+        response = await fetch(apiUrl, { headers: baseHeaders });
+    }
 
     if (!response.ok) {
         return NextResponse.json(

--- a/src/app/components/blogs/BlogPost.tsx
+++ b/src/app/components/blogs/BlogPost.tsx
@@ -36,6 +36,9 @@ export function BlogPost({ id }: BlogPostProps) {
     const { user, isLoading: isAuthLoading } = useAuth();
     // states
     const [markdownData, setMarkdownData] = useState<string | null>(null);
+    const [markdownStatus, setMarkdownStatus] = useState<'idle' | 'loading' | 'error' | 'done'>(
+        'idle',
+    );
 
     // ブログデータの取得
     const {
@@ -50,13 +53,29 @@ export function BlogPost({ id }: BlogPostProps) {
 
     // GitHubのURLからMarkdownデータを取得
     useEffect(() => {
-        const fetchMarkdownData = async () => {
-            if (blog && blog.github_url) {
-                const markdownData = await fetchMarkdown(blog.github_url);
-                setMarkdownData(markdownData);
+        if (!blog || !blog.github_url) {
+            return;
+        }
+        let cancelled = false;
+        setMarkdownStatus('loading');
+        (async () => {
+            try {
+                const content = await fetchMarkdown(blog.github_url);
+                if (cancelled) return;
+                if (content) {
+                    setMarkdownData(content);
+                    setMarkdownStatus('done');
+                } else {
+                    // 取得失敗（プロキシが null を返却。トークン失効・404 等）→ 無言の空白を避ける
+                    setMarkdownStatus('error');
+                }
+            } catch {
+                if (!cancelled) setMarkdownStatus('error');
             }
+        })();
+        return () => {
+            cancelled = true;
         };
-        fetchMarkdownData();
     }, [blog]);
 
     return (
@@ -115,13 +134,36 @@ export function BlogPost({ id }: BlogPostProps) {
                         </header>
 
                         <div className="">{blog.description}</div>
-                        <ReactMarkdown
-                            className="prose prose-sky max-w-none markdown-content"
-                            remarkPlugins={[remarkGfm, remarkBreaks]}
-                            rehypePlugins={[rehypeHighlight]}
-                        >
-                            {markdownData}
-                        </ReactMarkdown>
+
+                        {markdownStatus === 'loading' && (
+                            <div className="h-16 flex items-center justify-center">
+                                <PulseLoader color="#dddddd" size={10} />
+                            </div>
+                        )}
+
+                        {markdownData && (
+                            <ReactMarkdown
+                                className="prose prose-sky max-w-none markdown-content"
+                                remarkPlugins={[remarkGfm, remarkBreaks]}
+                                rehypePlugins={[rehypeHighlight]}
+                            >
+                                {markdownData}
+                            </ReactMarkdown>
+                        )}
+
+                        {blog.github_url && markdownStatus === 'error' && (
+                            <p className="text-gray-500">
+                                本文を読み込めませんでした。
+                                <a
+                                    href={blog.github_url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-sky-700 underline ml-1"
+                                >
+                                    GitHub で記事を見る
+                                </a>
+                            </p>
+                        )}
 
                         <div className="mt-12 pt-12 border-t border-sky-100">
                             <CommentsSection blogId={blog.id} />


### PR DESCRIPTION
## 背景 / 根本原因
公開サイトで **Zenn 記事の本文が表示されない**事象を調査した結果、本番の **`GITHUB_TOKEN`（Secret Manager）が失効**していた。

- 本番 `POST /api/github/markdown` → **401** `Failed to fetch Markdown content from GitHub`
- 同ファイルの GitHub raw（無認証）→ **200**（リポジトリ `kojikawazu/zenn-article-kk` は公開・ファイル存在）
- 無効トークン付き `api.github.com` → **401**（本番の挙動と一致）
- プロキシは失効トークンを `Authorization` に付けて呼ぶため 401 → `fetchMarkdown` が `null` → 本文が**無言で空白**に

> アプリのコード/CI/Dockerfile とは無関係の運用側（シークレット失効）の問題。本 PR はコード側の堅牢化。

## 変更
- **`route.ts`**: 認証付き取得が **401/403** の場合、公開リポ向けに **無認証で再取得**するフォールバックを追加。オーナーは `ALLOWED_REPO_OWNER` で制限済みのため、無認証で読めるのは公開リポのみ＝**private 漏洩リスクなし**（むしろ低下）。
- **`BlogPost.tsx`**: Markdown 取得状態（loading/error）を導入。取得失敗時は無言の空白を避け、**「GitHub で記事を見る」リンク**を表示。
- **テスト**: route ハンドラのユニットテストを追加（正常 / 401→無認証フォールバック成功 / 403許可外 / 400不正URL / フォールバック後失敗 など 7 ケース）。

## 検証
- `pnpm test`: 8 files / 48 tests 全 pass（うち route 7 ケース新規）
- 変更3ファイルは `tsc --noEmit`・Prettier クリーン

## 運用側の対応（別途・推奨）
本 PR で公開記事は復旧するが、レート制限/private 対応のため **`GITHUB_TOKEN` のローテーション**も推奨:
\`\`\`bash
gcloud secrets versions add github-token --data-file=- <<< "ghp_新しいトークン"
gcloud run services update <SERVICE_NAME> --region <REGION>   # 反映
\`\`\`

## Test plan
- [ ] `Pull Request Test`（unit + e2e）が green
- [ ] マージ後の本番で Zenn 記事本文が表示される（トークン失効中でも公開記事が表示されること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)