### PR TITLE
chore(eslint): eslint-plugin-jsdoc を導入し pnpm 環境で lint を復活

### DIFF
--- a/apps/front/eslint.config.mjs
+++ b/apps/front/eslint.config.mjs
@@ -1,6 +1,7 @@
 import nextPlugin from "@next/eslint-plugin-next";
 import reactPlugin from "eslint-plugin-react";
 import hooksPlugin from "eslint-plugin-react-hooks";
+import jsdoc from "eslint-plugin-jsdoc";
 import tseslint from "typescript-eslint";
 
 export default [
@@ -22,11 +23,70 @@ export default [
       ...hooksPlugin.configs.recommended.rules,
       "react/react-in-jsx-scope": "off",
       "react/prop-types": "off",
+      // 「async フェッチ前に loading 状態をセット」等は正当なパターン。error だと過剰なため
+      // 可視化目的の warn に留める（挙動変更を伴う修正は別タスク）。
+      "react-hooks/set-state-in-effect": "warn",
     },
     settings: {
       react: {
         version: "detect",
       },
+    },
+  },
+  // JSDoc 規約（TSDoc スタイル）の機械的に判定できる部分を強制する。
+  // 有効ルールの唯一の真実はこのブロック。方針の根拠は .claude/rules/jsdoc.md。
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    plugins: { jsdoc },
+    // TS 前提。型は JSDoc ではなくシグネチャに委ねる。
+    settings: { jsdoc: { mode: "typescript" } },
+    rules: {
+      // 型の再掲を禁止（TS シグネチャが型の唯一の真実）。
+      "jsdoc/no-types": "error",
+      // JSDoc ブロックを持つ関数は全引数を @param で説明する。
+      // 分割代入 props は型（XxxProps）が真実なので props.x 単位には展開しない。
+      "jsdoc/require-param": ["error", { checkDestructured: false, checkDestructuredRoots: false }],
+      "jsdoc/require-param-description": "error",
+      // @param 名と実引数名を突き合わせる（名前ズレ・順序・過不足を検出）。
+      // 本 repo は分割代入 props を per-prop（@param isOpen 等）で記述する慣習（jsdoc.md
+      // 「各プロパティに説明」に準拠）。分割代入ルート（props.x）単位の展開チェックは無効化し、
+      // トップレベルの @param 名照合のみ行う。
+      "jsdoc/check-param-names": ["error", { checkDestructured: false }],
+      // 返り値がある関数は @returns に意味を書く（.tsx コンポーネントは後続ブロックで除外）。
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      // 書いた JSDoc の体裁を整える。
+      "jsdoc/check-alignment": "warn",
+      "jsdoc/no-multi-asterisks": "warn",
+      // require-jsdoc は // 行コメントを誤検知するため未採用。ブロックの有無・質はレビューで確認する。
+    },
+  },
+  {
+    // React コンポーネント（JSX を返す .tsx）は @returns を要求しない（「@returns …の要素」はノイズ）。
+    // .ts のフック / lib / API では @returns 必須のまま。
+    files: ["src/**/*.tsx"],
+    plugins: { jsdoc },
+    rules: {
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off",
+      // コンポーネントは分割代入 props を per-prop（@param isOpen 等）で記述する慣習。
+      // flat な per-prop 名は check-param-names の分割代入照合と構造的に非互換のため、
+      // .tsx では無効化する（.ts の名前付き引数では有効のまま名前ズレを検出する）。
+      "jsdoc/check-param-names": "off",
+    },
+  },
+  {
+    // テストコード・テスト足場は「公開シンボル」ではないため JSDoc 必須系を免除する
+    // （jsdoc.md の必須対象は公開 API・コンポーネント props・フック等）。書かれた JSDoc の
+    // 整合性チェック（no-types / check-param-names）は残す。display-name もテストの
+    // インラインラッパーには不要。
+    files: ["src/**/__tests__/**", "src/**/*.test.{ts,tsx}", "src/test/**"],
+    rules: {
+      "jsdoc/require-param": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off",
+      "react/display-name": "off",
     },
   },
 ];

--- a/apps/front/package.json
+++ b/apps/front/package.json
@@ -9,7 +9,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx}\"",
     "test": "vitest run",
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@next/eslint-plugin-next": "^16.1.6",
     "@playwright/test": "^1.50.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
@@ -56,12 +57,16 @@
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.1.6",
     "eslint-config-prettier": "^10.0.1",
+    "eslint-plugin-jsdoc": "^63.0.10",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "jsdom": "^29.0.1",
     "playwright": "^1.58.1",
     "postcss": "^8",
     "prettier": "^3.4.2",
     "tailwindcss": "^3.4.1",
     "typescript": "^5",
+    "typescript-eslint": "^8.54.0",
     "vitest": "^4.1.2"
   }
 }

--- a/apps/front/src/app/api/_lib/proxy.ts
+++ b/apps/front/src/app/api/_lib/proxy.ts
@@ -1,11 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 /**
- * バックエンドAPIへのプロキシリクエスト
- * サーバーサイドでのみ実行され、バックエンドURLをクライアントに露出しない
+ * バックエンドAPIへのプロキシリクエスト。
+ * サーバーサイドでのみ実行され、バックエンドURLをクライアントに露出しない。
  *
  * Note: Next.js 16では req.text() + new NextResponse() パターンで
- * POSTルートが404になるバグがあるため、req.json() + NextResponse.json() を使用
+ * POSTルートが404になるバグがあるため、req.json() + NextResponse.json() を使用。
+ *
+ * @param req - クライアントからの受信リクエスト（Cookie・ボディを転送元とする）
+ * @param backendPath - バックエンド上の転送先パス（例: `/blogs/detail/:id`）
+ * @param options - 任意設定。`method` で HTTP メソッドを上書きできる（未指定時は `req.method`）
+ * @returns バックエンドの応答を整形した JSON レスポンス。`BACKEND_API_URL` 未設定時は 500
  */
 export async function proxyToBackend(
     req: NextRequest,

--- a/apps/front/src/app/api/github/markdown/route.ts
+++ b/apps/front/src/app/api/github/markdown/route.ts
@@ -2,10 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import matter from 'gray-matter';
 
 /**
- * GitHub Markdown取得プロキシ
+ * GitHub Markdown取得プロキシ（Route Handler）。
  * - GITHUB_TOKENをサーバーサイドでのみ使用し、クライアントに露出しない
  * - ALLOWED_REPO_OWNERで許可されたオーナーのリポジトリのみアクセス可能
  * - 許可外オーナーのリポジトリへのリクエストはトークンなしで実行（プライベートリポ漏洩防止）
+ *
+ * @param req - `{ url: string }`（GitHub の Markdown blob URL）を含む POST リクエスト
+ * @returns Markdown 本文の JSON。入力不正は 400、設定不備は 500、取得失敗は該当ステータス
  */
 export async function POST(req: NextRequest) {
     let body: unknown;

--- a/apps/front/src/app/hooks/useLikeBlog.ts
+++ b/apps/front/src/app/hooks/useLikeBlog.ts
@@ -11,7 +11,9 @@ import { generateVisitId } from '@/app/lib/api/blog-likes/generateVisitId';
 const VISIT_ID_KEY = process.env.NEXT_PUBLIC_VISIT_ID_KEY as string;
 
 /**
- * いいね機能のカスタムフック
+ * いいね機能のカスタムフック。訪問者IDの初期化・いいね済み一覧の取得・いいね登録/取消を提供する。
+ *
+ * @returns いいね操作関数（`likeBlog` / `unlikeBlog`）といいね判定関数（`hasLiked`）
  */
 export function useLikeBlog() {
     const queryClient = useQueryClient();
@@ -60,7 +62,10 @@ export function useLikeBlog() {
     });
 
     /**
-     * ブログがいいねされているか判定
+     * 指定ブログが（訪問者単位で）いいね済みか判定する。
+     *
+     * @param blogId - 判定対象のブログ ID
+     * @returns いいね済みなら `true`
      */
     const hasLiked = (blogId: string) => likedPosts?.includes(blogId) ?? false;
 

--- a/apps/front/src/app/layout.tsx
+++ b/apps/front/src/app/layout.tsx
@@ -14,9 +14,9 @@ export const metadata: Metadata = {
 };
 
 /**
- * RootLayout
- * @param children
- * @returns
+ * アプリのルートレイアウト。全ページ共通の Provider ツリー（Query/Auth/Global/Toast）で子要素を包む。
+ *
+ * @param children - 各ルートページの要素
  */
 export default function RootLayout({
     children,

--- a/apps/front/src/app/lib/api/blog-likes/generateVisitId.ts
+++ b/apps/front/src/app/lib/api/blog-likes/generateVisitId.ts
@@ -1,7 +1,10 @@
 import { COMMON_CONSTANTS } from '@/app/utils/const/constants';
 
 /**
- * 訪問者IDを生成
+ * 訪問者ID（いいね重複防止用）を BFF 経由で生成・取得する。
+ *
+ * @returns 生成された訪問者 ID
+ * @throws {Error} 生成 API がエラーステータスを返した場合
  */
 export async function generateVisitId(): Promise<string> {
     const response = await fetch(COMMON_CONSTANTS.URL.BLOG_LIKE_GENERATE_VISIT_ID, {

--- a/apps/front/src/app/lib/api/github/fetchGitHub.ts
+++ b/apps/front/src/app/lib/api/github/fetchGitHub.ts
@@ -2,10 +2,12 @@
 import { COMMON_CONSTANTS } from '@/app/utils/const/constants';
 
 /**
- * GitHub URLからMarkdownファイルの内容を取得する
- * Route Handler経由でサーバーサイドで取得するため、GITHUB_TOKENは露出しない
- * @param githubUrls
- * @returns markdown content or null
+ * GitHub URLからMarkdownファイルの内容を取得する。
+ * Route Handler経由でサーバーサイドで取得するため、GITHUB_TOKENは露出しない。
+ *
+ * @param githubUrls - 取得対象の Markdown ファイルの GitHub URL
+ * @returns Markdown 本文。取得失敗（プロキシが null 返却・トークン失効・404 等）時は `null`
+ * @throws {Error} fetch 自体が失敗した場合（ネットワークエラー等）
  */
 export const fetchMarkdown = async (githubUrls: string) => {
     try {

--- a/apps/front/src/app/provider/QueryProvider.tsx
+++ b/apps/front/src/app/provider/QueryProvider.tsx
@@ -5,9 +5,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 const queryClient = new QueryClient();
 
 /**
- * QueryProvider
- * @param children
- * @returns
+ * TanStack Query の QueryClient をツリーに供給する Provider。
+ *
+ * @param children - Provider 配下にレンダリングする子要素
  */
 export const QueryProvider = ({ children }: { children: React.ReactNode }) => {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;

--- a/docs/10-miscellaneous-specification.md
+++ b/docs/10-miscellaneous-specification.md
@@ -37,7 +37,9 @@
 
 ### リンター（ESLint 9）
 
-フラットコンフィグ形式（`eslint.config.mjs`）を使用。
+フラットコンフィグ形式（`eslint.config.mjs`）を使用。実行は `pnpm lint`（= `eslint`）。
+
+> Next.js 16 で `next lint` は削除されたため、lint スクリプトは `eslint` を直接呼び出す。`eslint.config.mjs` が import する各プラグインは、pnpm の厳格な `node_modules` で解決できるよう **直接 devDependency** として明示している（`eslint-config-next` の推移的依存に依存しない）。
 
 | プラグイン | 用途 |
 |-----------|------|
@@ -45,7 +47,23 @@
 | `eslint-plugin-react` | Reactルール |
 | `eslint-plugin-react-hooks` | Hooksルール |
 | `typescript-eslint` | TypeScriptルール |
+| `eslint-plugin-jsdoc` | JSDoc（TSDoc）規約の機械強制（`.claude/rules/jsdoc.md` 準拠） |
 | `eslint-config-prettier` | Prettierとの競合解消 |
+
+#### JSDoc ルール（`eslint-plugin-jsdoc`）
+
+`src/**/*.{ts,tsx}` に適用。**書かれた JSDoc の整合性を検証**する方針（`require-jsdoc` による有無強制はしない。有無・質はレビューで担保）。
+
+| ルール | 設定 | 意図 |
+|-------|------|------|
+| `jsdoc/no-types` | error | 型ブレース（`@param {string}`）禁止。型は TS シグネチャが唯一の真実 |
+| `jsdoc/require-param` / `-description` | error | JSDoc を持つ関数は全引数を説明（分割代入ルートは非展開） |
+| `jsdoc/check-param-names` | error（`.ts`のみ） | `@param` 名と実引数の照合。`.tsx` は per-prop 慣習と非互換のため off |
+| `jsdoc/require-returns` / `-description` | error（`.ts`のみ） | 戻り値の意味付け必須。`.tsx`（JSX 返却）は off |
+| `jsdoc/check-alignment` / `no-multi-asterisks` | warn | 体裁 |
+
+- **テストコード**（`__tests__/`・`*.test.*`・`src/test/`）は公開シンボルでないため JSDoc 必須系を免除。
+- `react-hooks/set-state-in-effect` は正当なパターン（async フェッチ前の loading セット等）に過剰反応するため `warn` に降格。挙動を伴う修正は `docs/11-tasks.md` の課題として管理。
 
 ### カスタムルール
 
@@ -202,7 +220,7 @@ gcloud secrets versions add github-token --data-file=- <<< "ghp_xxxxx"
 |-----------|------|
 | `typescript`, `@types/*` | TypeScript |
 | `tailwindcss`, `postcss` | CSS |
-| `eslint`, `eslint-config-next`, `eslint-config-prettier` | リンター |
+| `eslint`, `eslint-config-next`, `eslint-config-prettier`, `@next/eslint-plugin-next`, `eslint-plugin-react`, `eslint-plugin-react-hooks`, `typescript-eslint`, `eslint-plugin-jsdoc` | リンター |
 | `prettier` | フォーマッター |
 | `vitest`, `@vitejs/plugin-react`, `jsdom` | ユニットテスト（実行環境） |
 | `@testing-library/react`, `@testing-library/dom`, `@testing-library/jest-dom`, `@testing-library/user-event` | ユニットテスト（DOM/フック検証） |

--- a/docs/11-tasks.md
+++ b/docs/11-tasks.md
@@ -112,6 +112,9 @@
 
 ## 今後の改善候補
 
+- [ ] ESLint で warn に留めている React Hooks 警告の解消（挙動確認しつつ対応）:
+  - `react-hooks/set-state-in-effect`（`BlogPost.tsx`・async フェッチ前の loading セット）
+  - `react-hooks/exhaustive-deps`（`EditPost.tsx` の `isLoading`・`Home.tsx` の `setGlobalData`）
 - [ ] ユニットテストのカバレッジ拡充（現在はスキーマ・カスタムフックのみ。コンポーネント等へ拡大）
 - [ ] SSR / SSGの活用（現在は全ページCSR）
 - [ ] 画像アップロード機能

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.3
+      '@next/eslint-plugin-next':
+        specifier: ^16.1.6
+        version: 16.1.6
       '@playwright/test':
         specifier: ^1.50.1
         version: 1.58.1
@@ -116,6 +119,15 @@ importers:
       eslint-config-prettier:
         specifier: ^10.0.1
         version: 10.1.8(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-jsdoc:
+        specifier: ^63.0.10
+        version: 63.2.0(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-react:
+        specifier: ^7.37.5
+        version: 7.37.5(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-react-hooks:
+        specifier: ^7.0.1
+        version: 7.0.1(eslint@9.39.2(jiti@1.21.7))
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1
@@ -134,6 +146,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.54.0
+        version: 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@20.19.30)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@types/node@20.19.30)(jiti@1.21.7))
@@ -277,6 +292,14 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@es-joy/jsdoccomment@0.88.0':
+    resolution: {integrity: sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@es-joy/resolve.exports@1.2.0':
+    resolution: {integrity: sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==}
+    engines: {node: '>=10'}
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -733,6 +756,10 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@sindresorhus/base62@1.0.0':
+    resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
+    engines: {node: '>=18'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -796,6 +823,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -875,6 +905,10 @@ packages:
 
   '@typescript-eslint/types@8.54.0':
     resolution: {integrity: sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.65.0':
+    resolution: {integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.54.0':
@@ -1053,6 +1087,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -1074,6 +1113,10 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -1244,6 +1287,10 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  comment-parser@1.4.7:
+    resolution: {integrity: sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==}
+    engines: {node: '>= 12.0.0'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1477,6 +1524,12 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
+  eslint-plugin-jsdoc@63.2.0:
+    resolution: {integrity: sha512-tccz9igEV5mTKVAwo/KwXqKP7ENqa3a+LpRFuEPAP3k/+SXG4T0sOvA+c2wwTD/TLNrH9MCW4LIu4xEExkJdzg==}
+    engines: {node: ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+
   eslint-plugin-jsx-a11y@6.10.2:
     resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
@@ -1507,6 +1560,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1520,6 +1577,10 @@ packages:
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -1743,6 +1804,9 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -1927,6 +1991,10 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdoc-type-pratt-parser@7.2.0:
+    resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
+    engines: {node: '>=20.0.0'}
 
   jsdom@29.0.1:
     resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
@@ -2314,6 +2382,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-deep-merge@2.0.1:
+    resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
+
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
@@ -2371,6 +2442,12 @@ packages:
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse-imports-exports@0.2.4:
+    resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+
+  parse-statements@1.0.11:
+    resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
@@ -2589,6 +2666,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2649,6 +2730,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -2698,6 +2784,15 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -2829,6 +2924,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  to-valid-identifier@1.0.0:
+    resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
+    engines: {node: '>=20'}
 
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
@@ -3285,6 +3384,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@es-joy/jsdoccomment@0.88.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@typescript-eslint/types': 8.65.0
+      comment-parser: 1.4.7
+      esquery: 1.7.0
+      jsdoc-type-pratt-parser: 7.2.0
+
+  '@es-joy/resolve.exports@1.2.0': {}
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@1.21.7))':
     dependencies:
       eslint: 9.39.2(jiti@1.21.7)
@@ -3602,6 +3711,8 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@sindresorhus/base62@1.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -3673,6 +3784,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/estree@1.0.9': {}
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -3741,7 +3854,7 @@ snapshots:
   '@typescript-eslint/project-service@8.54.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.54.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.54.0
+      '@typescript-eslint/types': 8.65.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3770,6 +3883,8 @@ snapshots:
 
   '@typescript-eslint/types@8.54.0': {}
 
+  '@typescript-eslint/types@8.65.0': {}
+
   '@typescript-eslint/typescript-estree@8.54.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/project-service': 8.54.0(typescript@5.9.3)
@@ -3778,7 +3893,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.54.0
       debug: 4.4.3
       minimatch: 9.0.9
-      semver: 7.7.3
+      semver: 7.8.5
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -3912,7 +4027,13 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
   acorn@8.15.0: {}
+
+  acorn@8.17.0: {}
 
   ajv@6.14.0:
     dependencies:
@@ -3935,6 +4056,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
+
+  are-docs-informative@0.0.2: {}
 
   arg@5.0.2: {}
 
@@ -4127,6 +4250,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@4.1.1: {}
+
+  comment-parser@1.4.7: {}
 
   concat-map@0.0.1: {}
 
@@ -4434,6 +4559,26 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-plugin-jsdoc@63.2.0(eslint@9.39.2(jiti@1.21.7)):
+    dependencies:
+      '@es-joy/jsdoccomment': 0.88.0
+      '@es-joy/resolve.exports': 1.2.0
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.7
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint: 9.39.2(jiti@1.21.7)
+      espree: 11.2.0
+      esquery: 1.7.0
+      html-entities: 2.6.0
+      object-deep-merge: 2.0.1
+      parse-imports-exports: 0.2.4
+      semver: 7.8.5
+      spdx-expression-parse: 4.0.0
+      to-valid-identifier: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       aria-query: 5.3.2
@@ -4495,6 +4640,8 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
+  eslint-visitor-keys@5.0.1: {}
+
   eslint@9.39.2(jiti@1.21.7):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
@@ -4541,6 +4688,12 @@ snapshots:
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 5.0.1
 
   esprima@4.0.1: {}
 
@@ -4778,6 +4931,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-entities@2.6.0: {}
+
   html-url-attributes@3.0.1: {}
 
   ignore@5.3.2: {}
@@ -4959,6 +5114,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdoc-type-pratt-parser@7.2.0: {}
 
   jsdom@29.0.1:
     dependencies:
@@ -5530,6 +5687,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-deep-merge@2.0.1: {}
+
   object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
@@ -5610,6 +5769,12 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  parse-imports-exports@0.2.4:
+    dependencies:
+      parse-statements: 1.0.11
+
+  parse-statements@1.0.11: {}
 
   parse5@8.0.0:
     dependencies:
@@ -5850,6 +6015,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  reserved-identifiers@1.2.0: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -5931,6 +6098,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.3: {}
+
+  semver@7.8.5: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -6025,6 +6194,15 @@ snapshots:
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
 
   sprintf-js@1.0.3: {}
 
@@ -6193,6 +6371,11 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  to-valid-identifier@1.0.0:
+    dependencies:
+      '@sindresorhus/base62': 1.0.0
+      reserved-identifiers: 1.2.0
 
   tough-cookie@6.0.1:
     dependencies:


### PR DESCRIPTION
## 概要

`youtube-my-collection` を参考に **JSDoc の ESLint 強制（`eslint-plugin-jsdoc`）** を導入。作業中に判明した「pnpm 移行 + Next 16 化で lint 基盤が壊れていた」問題も最小修正で復活させた。

## 変更点

- **JSDoc lint 導入**: `src/**/*.{ts,tsx}` に `no-types` / `require-param(+desc)` / `require-returns(+desc)` / `check-param-names` を適用。有無強制（`require-jsdoc`）はせず整合性のみ検証。`.tsx` は `@returns`・`check-param-names` を除外、テストは必須系を免除（`.claude/rules/jsdoc.md` 準拠）
- **lint 基盤の最小修正**: `next lint`（Next 16 で削除）→ `eslint` に変更。設定が import する4プラグイン（`@next/eslint-plugin-next` / `eslint-plugin-react` / `eslint-plugin-react-hooks` / `typescript-eslint`）を pnpm で解決できるよう直接 devDependency 化
- **既存コード**: JSDoc 欠落を補填（コメントのみ・挙動不変）。`react-hooks/set-state-in-effect` を `warn` 降格
- **ドキュメント**: `docs/10`（ESLint 節）・`docs/11`（残 React 警告を改善候補化）を同期

## 確認事項

- `pnpm lint` → **0 errors**（警告3件は既存の React Hooks 事項・非ブロッキング、`docs/11` に課題化）
- `pnpm test` → **48/48 passed**
- 設計判断（要レビュー）: `.tsx` の per-prop `@param` 慣習と `check-param-names` が構造的に非互換のため `.tsx` のみ off とした。参考元流儀（props に `@param` を書かない）へ寄せる選択もあり得る

🤖 Generated with [Claude Code](https://claude.com/claude-code)