### PR TITLE
docs(tsdoc): 公開シンボルへ不足していた TSDoc を追加

### DIFF
--- a/apps/front/src/app/api/auth/check/route.ts
+++ b/apps/front/src/app/api/auth/check/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
+/**
+ * 認証状態を確認する（BFF プロキシ → バックエンド `/users/auth-check`）。
+ * 未認証（401/404）でもコンソールエラーを避けるため 200 + `null` を返す。
+ *
+ * @param req - Cookie を含む受信リクエスト
+ * @returns 認証済みならユーザー情報、未認証なら 200 + `null`
+ */
 export async function GET(req: NextRequest) {
     const res = await proxyToBackend(req, '/users/auth-check');
 

--- a/apps/front/src/app/api/auth/login/route.ts
+++ b/apps/front/src/app/api/auth/login/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
+/**
+ * ログイン（BFF プロキシ → バックエンド `/users/login`）。認証 Cookie を転送する。
+ *
+ * @param req - メール／パスワードを含む POST リクエスト
+ * @returns バックエンドのログイン応答
+ */
 export async function POST(req: NextRequest) {
     return proxyToBackend(req, '/users/login');
 }

--- a/apps/front/src/app/api/auth/logout/route.ts
+++ b/apps/front/src/app/api/auth/logout/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
+/**
+ * ログアウト（BFF プロキシ → バックエンド `/users/logout`）。認証 Cookie を転送する。
+ *
+ * @param req - 受信リクエスト
+ * @returns バックエンドのログアウト応答
+ */
 export async function POST(req: NextRequest) {
     return proxyToBackend(req, '/users/logout');
 }

--- a/apps/front/src/app/api/blog-likes/[blogId]/route.ts
+++ b/apps/front/src/app/api/blog-likes/[blogId]/route.ts
@@ -1,11 +1,25 @@
 import { NextRequest } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
+/**
+ * いいねを登録する（BFF プロキシ → `/blog-likes/create/:blogId`）。
+ * パスパラメータ `blogId` を転送先に埋め込む。
+ *
+ * @param req - 訪問者情報を含む POST リクエスト
+ * @returns バックエンドのいいね登録応答
+ */
 export async function POST(req: NextRequest, { params }: { params: Promise<{ blogId: string }> }) {
     const { blogId } = await params;
     return proxyToBackend(req, `/blog-likes/create/${blogId}`);
 }
 
+/**
+ * いいねを取り消す（BFF プロキシ → `/blog-likes/delete/:blogId`）。
+ * パスパラメータ `blogId` を転送先に埋め込む。
+ *
+ * @param req - 訪問者情報を含む DELETE リクエスト
+ * @returns バックエンドのいいね取消応答
+ */
 export async function DELETE(
     req: NextRequest,
     { params }: { params: Promise<{ blogId: string }> },

--- a/apps/front/src/app/api/blog-likes/generate-visit-id/route.ts
+++ b/apps/front/src/app/api/blog-likes/generate-visit-id/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
+/**
+ * 訪問者 ID を生成する（BFF プロキシ → `/blog-likes/generate-visit-id`）。
+ * いいねの重複防止に用いる訪問者 ID を Cookie として払い出す。
+ *
+ * @param req - 受信リクエスト
+ * @returns 生成された訪問者 ID を含むバックエンド応答
+ */
 export async function GET(req: NextRequest) {
     return proxyToBackend(req, '/blog-likes/generate-visit-id');
 }

--- a/apps/front/src/app/api/blog-likes/route.ts
+++ b/apps/front/src/app/api/blog-likes/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
+/**
+ * いいね済みブログの一覧を取得する（BFF プロキシ → `/blog-likes`）。
+ *
+ * @param req - 訪問者 Cookie を含む受信リクエスト
+ * @returns 訪問者がいいね済みのブログ一覧
+ */
 export async function GET(req: NextRequest) {
     return proxyToBackend(req, '/blog-likes');
 }

--- a/apps/front/src/app/api/blogs/[id]/route.ts
+++ b/apps/front/src/app/api/blogs/[id]/route.ts
@@ -1,16 +1,34 @@
 import { NextRequest } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
+/**
+ * ブログ詳細を取得する（BFF プロキシ → `/blogs/detail/:id`）。
+ *
+ * @param req - 受信リクエスト
+ * @returns 指定 ID のブログ詳細
+ */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
     return proxyToBackend(req, `/blogs/detail/${id}`);
 }
 
+/**
+ * ブログを更新する（BFF プロキシ → `/blogs/update/:id`。オーナーのみ）。
+ *
+ * @param req - 更新内容を含む PUT リクエスト
+ * @returns バックエンドの更新応答
+ */
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
     return proxyToBackend(req, `/blogs/update/${id}`);
 }
 
+/**
+ * ブログを削除する（BFF プロキシ → `/blogs/delete/:id`。オーナーのみ）。
+ *
+ * @param req - DELETE リクエスト
+ * @returns バックエンドの削除応答
+ */
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
     return proxyToBackend(req, `/blogs/delete/${id}`);

--- a/apps/front/src/app/api/blogs/categories/route.ts
+++ b/apps/front/src/app/api/blogs/categories/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
+/**
+ * カテゴリ一覧を取得する（BFF プロキシ → `/blogs/categories`）。
+ *
+ * @param req - 受信リクエスト
+ * @returns カテゴリ一覧
+ */
 export async function GET(req: NextRequest) {
     return proxyToBackend(req, '/blogs/categories');
 }

--- a/apps/front/src/app/api/blogs/popular/[count]/route.ts
+++ b/apps/front/src/app/api/blogs/popular/[count]/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
+/**
+ * 人気ブログを取得する（BFF プロキシ → `/blogs/popular/:count`）。
+ * パスパラメータ `count` で件数（例: TOP5）を指定する。
+ *
+ * @param req - 受信リクエスト
+ * @returns いいね数上位のブログ一覧
+ */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ count: string }> }) {
     const { count } = await params;
     return proxyToBackend(req, `/blogs/popular/${count}`);

--- a/apps/front/src/app/api/blogs/route.ts
+++ b/apps/front/src/app/api/blogs/route.ts
@@ -1,10 +1,22 @@
 import { NextRequest } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
+/**
+ * ブログ一覧を取得する（BFF プロキシ → `/blogs`）。
+ *
+ * @param req - 受信リクエスト
+ * @returns ブログ一覧
+ */
 export async function GET(req: NextRequest) {
     return proxyToBackend(req, '/blogs');
 }
 
+/**
+ * ブログを新規作成する（BFF プロキシ → `/blogs/create`。認証ユーザーのみ）。
+ *
+ * @param req - 記事内容を含む POST リクエスト
+ * @returns バックエンドの作成応答
+ */
 export async function POST(req: NextRequest) {
     return proxyToBackend(req, '/blogs/create');
 }

--- a/apps/front/src/app/api/blogs/tags/route.ts
+++ b/apps/front/src/app/api/blogs/tags/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
+/**
+ * タグ一覧を取得する（BFF プロキシ → `/blogs/tags`）。
+ *
+ * @param req - 受信リクエスト
+ * @returns タグ一覧
+ */
 export async function GET(req: NextRequest) {
     return proxyToBackend(req, '/blogs/tags');
 }

--- a/apps/front/src/app/api/comments/[blogId]/route.ts
+++ b/apps/front/src/app/api/comments/[blogId]/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
+/**
+ * 指定ブログのコメント一覧を取得する（BFF プロキシ → `/comments/blog/:blogId`）。
+ *
+ * @param req - 受信リクエスト
+ * @returns 指定ブログに紐づくコメント一覧
+ */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ blogId: string }> }) {
     const { blogId } = await params;
     return proxyToBackend(req, `/comments/blog/${blogId}`);

--- a/apps/front/src/app/api/comments/route.ts
+++ b/apps/front/src/app/api/comments/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest } from 'next/server';
 import { proxyToBackend } from '@/app/api/_lib/proxy';
 
+/**
+ * コメントを投稿する（BFF プロキシ → `/comments/create`。ゲスト投稿可）。
+ *
+ * @param req - ゲスト名とコメント本文を含む POST リクエスト
+ * @returns バックエンドのコメント作成応答
+ */
 export async function POST(req: NextRequest) {
     return proxyToBackend(req, '/comments/create');
 }

--- a/apps/front/src/app/contexts/AuthContext.tsx
+++ b/apps/front/src/app/contexts/AuthContext.tsx
@@ -20,7 +20,11 @@ interface AuthContextType {
 // Context の作成
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-// Provider コンポーネント
+/**
+ * 認証状態を供給する Provider。ログイン中ユーザー・`signIn` / `signOut` をツリーへ提供する。
+ *
+ * @param children - Provider 配下にレンダリングする子要素
+ */
 export function AuthProvider({ children }: { children: ReactNode }) {
     // router
     const router = useRouter();
@@ -121,7 +125,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
-// Context を利用するカスタムフック
+/**
+ * 認証コンテキストを取得するカスタムフック。
+ *
+ * @returns 認証状態と操作（`user` / `isLoading` / `signIn` / `signOut`）
+ * @throws {Error} `AuthProvider` の外側で呼ばれた場合
+ */
 export function useAuth() {
     const context = useContext(AuthContext);
     if (!context) {

--- a/apps/front/src/app/layout.tsx
+++ b/apps/front/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { GlobalProvider } from '@/app/contexts/GlobalContext';
 // css
 import './globals.css';
 
+/** アプリ共通の HTML メタデータ（Next.js が `<head>` に反映する）。 */
 export const metadata: Metadata = {
     title: 'Echo Blog App',
     description: 'Echo Blog App',

--- a/apps/front/src/app/stores/authStores.ts
+++ b/apps/front/src/app/stores/authStores.ts
@@ -19,6 +19,10 @@ const sampleUser: User = {
     updated_at: new Date().toISOString(),
 };
 
+/**
+ * 認証状態を扱う Zustand ストア（開発用サンプル。本番の認証は `AuthContext` を使用）。
+ * サインイン/サインアップ/サインアウトとサンプルユーザーによる初期化を提供する。
+ */
 export const useAuthStore = create<AuthState>((set) => ({
     user: null,
     loading: false,

--- a/apps/front/src/app/stores/blogStores.ts
+++ b/apps/front/src/app/stores/blogStores.ts
@@ -208,6 +208,10 @@ const saveLikedPosts = (posts: string[]) => {
     localStorage.setItem(LIKED_POSTS_KEY, JSON.stringify(posts));
 };
 
+/**
+ * ブログ一覧・検索・フィルタ・ページネーションといいね状態を扱う Zustand ストア（開発用サンプル）。
+ * いいねは localStorage（`techblog_liked_posts`）に永続化する。
+ */
 export const useBlogStore = create<BlogState>((set, get) => ({
     blogs: initialBlogs,
     filteredBlogs: initialBlogs,

--- a/apps/front/src/app/stores/commentStores.ts
+++ b/apps/front/src/app/stores/commentStores.ts
@@ -29,6 +29,9 @@ const initialComments: Comment[] = [
     },
 ];
 
+/**
+ * コメント一覧の取得（ページング）と追加を扱う Zustand ストア（開発用サンプル・初期データ入り）。
+ */
 export const useCommentStore = create<CommentState>((set, get) => ({
     comments: initialComments,
     totalPages: 1,

--- a/apps/front/src/app/types/blogs.ts
+++ b/apps/front/src/app/types/blogs.ts
@@ -1,30 +1,61 @@
+/**
+ * ブログ記事のデータ型。バックエンド API のレスポンス／一覧・詳細表示の基本単位。
+ */
 export interface Blog {
+    /** ブログの一意な ID（UUID） */
     id: string;
+    /** 投稿者（オーナー）のユーザー ID */
     user_id: string;
+    /** 記事タイトル */
     title: string;
+    /** 本文 Markdown を配置した GitHub の blob URL（未設定可） */
     github_url?: string;
+    /** カテゴリ名 */
     category: string;
+    /** タグ名の配列 */
     tags: string[];
+    /** 記事の概要文（一覧カード等に表示） */
     description: string;
+    /** いいね数 */
     likes: number;
+    /** コメント件数 */
     comment_cnt: number;
+    /** 作成日時（ISO 8601 文字列） */
     created_at: string;
+    /** 更新日時（ISO 8601 文字列） */
     updated_at: string;
 }
 
+/**
+ * ブログへのコメントのデータ型。ゲスト投稿を含む。
+ */
 export interface Comment {
+    /** コメントの一意な ID */
     id: string;
+    /** 紐づくブログの ID */
     blog_id: string;
+    /** 投稿者名（ゲスト名） */
     guest_user: string;
+    /** コメント本文 */
     comment: string;
+    /** 返信先コメントの ID（トップレベルは未設定）。返信機能は未実装で型のみ存在 */
     parent_id?: string;
+    /** 作成日時（ISO 8601 文字列） */
     created_at: string;
 }
 
+/**
+ * ブログのいいね（訪問者単位）のデータ型。訪問者 ID で重複いいねを防ぐ。
+ */
 export interface BlogLike {
+    /** いいねレコードの一意な ID */
     id: string;
+    /** いいね対象のブログ ID */
     blog_id: string;
+    /** いいねした訪問者の ID */
     visit_id: string;
+    /** 作成日時（ISO 8601 文字列） */
     created_at: string;
+    /** 更新日時（ISO 8601 文字列） */
     updated_at: string;
 }

--- a/apps/front/src/app/types/users.ts
+++ b/apps/front/src/app/types/users.ts
@@ -1,7 +1,15 @@
+/**
+ * 認証ユーザーのデータ型。ログイン中ユーザーの情報を表す。
+ */
 export interface User {
+    /** ユーザーの一意な ID */
     id: string;
+    /** 表示名 */
     name: string;
+    /** メールアドレス（ログイン ID） */
     email: string;
+    /** 作成日時（ISO 8601 文字列） */
     created_at: string;
+    /** 更新日時（ISO 8601 文字列） */
     updated_at: string;
 }

--- a/apps/front/src/app/utils/const/constants.ts
+++ b/apps/front/src/app/utils/const/constants.ts
@@ -1,3 +1,7 @@
+/**
+ * アプリ全体で共有する定数。API エンドポイント（`/api/*`）・トースト文言・各種設定値を集約する。
+ * 文言・URL をコンポーネントに直書きせず、ここを唯一の定義元とする。
+ */
 export const COMMON_CONSTANTS = {
     URL: {
         LOGIN: '/api/auth/login',


### PR DESCRIPTION
## 概要

`.claude/rules/jsdoc.md`（JSDoc/TSDoc 規約）に基づき、TSDoc が欠けていた公開シンボルへコメントを追加しました。ドキュメントのみの変更で、挙動・型シグネチャの変更はありません。

## 変更点

- **型定義**（`types/blogs.ts`, `types/users.ts`）: `Blog` / `Comment` / `BlogLike` / `User` の各プロパティに説明を付与
- **BFF Route Handlers**（`api/**`）: 各エンドポイントの要約・`@param`・`@returns` を追加
- **認証コンテキスト**（`contexts/AuthContext.tsx`）: `AuthProvider` / `useAuth` に要約・`@param`・`@returns`・`@throws` を付与
- **Zustand ストア・定数・レイアウト**: 公開シンボルへ TSDoc を追加

規約どおり、型ブレース（`{string}` 等）は書かず、意図・意味・制約を日本語で記述しています。

## 確認してほしい点

- JSDoc 規約（要約行必須・`@param`/`@returns`/`@throws`・型ブレース非併記）への準拠
- `pnpm lint`（eslint-plugin-jsdoc）が通ること

## ドキュメント影響

コード挙動・API 契約・型構造の変更はなくコメント追記のみのため、`docs/` の仕様書更新は不要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)