### PR TITLE
chore(ci): デプロイWFのイメージcleanupを整理（デッドコード除去）

### DIFF
--- a/.github/workflows/deploy_to_googlecloud.yml
+++ b/.github/workflows/deploy_to_googlecloud.yml
@@ -62,13 +62,13 @@ jobs:
               run: |
                   IMAGE_NAME="${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.REPO_NAME }}/${{ secrets.APP_NAME }}"
 
-                  # 最新5つのタグを取得
-                  KEEP_IMAGES=$(gcloud artifacts docker images list ${IMAGE_NAME} --format="value(DIGEST)" --sort-by="~UPDATE_TIME" | head -n 5)
-
-                  # すべてのタグを取得し、最新5つを除外したものを削除
-                  gcloud artifacts docker images list ${IMAGE_NAME} --format="value(DIGEST)" --sort-by="~UPDATE_TIME" | tail -n +6 | while read -r DIGEST; do
-                      if [[ ! -z "${DIGEST}" ]]; then
-                          echo "Deleting old image: ${IMAGE_NAME}:${DIGEST}"
-                          gcloud artifacts docker images delete "$IMAGE_NAME@$DIGEST" --quiet
-                      fi
-                  done
+                  # 更新時刻の新しい順に並べ、最新5世代を残して6件目以降を削除する
+                  gcloud artifacts docker images list "${IMAGE_NAME}" \
+                      --format="value(DIGEST)" --sort-by="~UPDATE_TIME" \
+                    | tail -n +6 \
+                    | while read -r DIGEST; do
+                          if [[ -n "${DIGEST}" ]]; then
+                              echo "Deleting old image: ${IMAGE_NAME}@${DIGEST}"
+                              gcloud artifacts docker images delete "${IMAGE_NAME}@${DIGEST}" --quiet
+                          fi
+                      done


### PR DESCRIPTION
## 概要

Cloud Run デプロイ WF（`deploy_to_googlecloud.yml`）の「Cleanup old images」ステップを整理する。**最新5世代保管の挙動は不変**のまま、デッドコードと冗長な API 呼び出しを除去する。

## 背景（現状の問題）

- `KEEP_IMAGES=$(... | head -n 5)` を計算しているが**変数がどこにも使われていない**（デッドコード）。実際の保持は後続の `tail -n +6` が担っている。
- そのため `gcloud artifacts docker images list` を**2回**呼んでおり無駄がある。
- 削除ログが `${IMAGE_NAME}:${DIGEST}` だが digest 参照は `@` が正（表示上の軽微な誤り）。

## 変更内容

- 未使用 `KEEP_IMAGES` 行と対応コメントを削除 → `gcloud list` を **2回→1回**に集約
- 削除ループは維持（最新5世代を残し6件目以降を削除）
- ログ文字列を `@${DIGEST}` に修正、`[[ ! -z ]]`→`[[ -n ]]`・変数クォートの軽微な堅牢化

保管ロジックは引き続き CI に置く方針（terraform `cleanup_policies` への移管は今回スコープ外）。

## 検証

- `ruby -ryaml` で YAML パース OK（8ステップ、cleanup `run:` が意図どおり）
- 挙動不変（`--sort-by="~UPDATE_TIME"` の新しい順で5世代保持 → 以降削除）

## ドキュメント影響

`docs/09-architecture-specification.md` のデプロイフローは push/deploy（1〜4）のみ記載で cleanup ステップは元々未記載。挙動も不変のため更新不要。

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)