### PR TITLE
chore(rules): 関心別ディレクトリ規約（schemas/・repositories/）を取り込み

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -52,6 +52,23 @@ globs: "apps/front/src/app/components/**,apps/front/src/app/hooks/**,apps/front/
 - `type` / `interface` は型本体・各メンバーともにコメント必須（`jsdoc.md`）。
 - **マジックナンバー・マジック文字列を直接書かない**（判断軸は型と同じ「参照範囲」）。ただし union の元になる定数は、導出される型と**同じファイルに同居**させる。環境変数は定数に含めない。詳細は `typescript.md`「定数の配置」に従う。
 
+## 関心別にディレクトリを切る
+
+`types/` `constants/` `schemas/` `repositories/` は**それぞれ独立したディレクトリ**として置く（本プロジェクトでは `src/app/` 直下）。いずれも**単一ファイルにまとめない**（`utils/const/constants.ts` のように 1 ファイルへ詰め込む形にしない。ドメイン単位でファイルを分ける）。詳細は `typescript.md`「型定義の配置」「定数の配置」「スキーマの配置」に従う。
+
+| ディレクトリ | 置くもの | 置かないもの |
+|---|---|---|
+| `types/` | 2 箇所以上から参照される型 | 値・ロジック |
+| `constants/` | 全環境で不変な値 | 環境変数・型を導出する定数（`types/` 側へ） |
+| `schemas/` | Zod スキーマ（フォーム・API レスポンスの検証） | 検証を伴わない型定義（`types/` へ） |
+| `repositories/` | **API アクセス**（`fetch` / BFF 呼び出し） | UI・画面都合の整形・業務判断 |
+| `lib/` | **通信を持たない純粋ユーティリティ**（日付整形・計算等） | API アクセス（`repositories/` へ）・定数・型 |
+
+- **`fetch` を書いてよいのは API アクセス層だけ**。コンポーネント・hooks・`lib/` の純粋関数から直接叩かない。呼び出し口を 1 箇所に閉じることで、Cookie 転送・エラー処理・リトライの実装が散らばらない。
+- ディレクトリ名は**複数形で統一**する（`types` / `constants` / `schemas` / `repositories`）。
+
+> **現状**: 本プロジェクトの API アクセス層は `lib/api/`（`fetchBlogs.ts` 等）、スキーマは単数形 `schema/`、定数は `utils/const/constants.ts` の 1 ファイルに置かれている。既存コードは即違反としない。`repositories/` への切り出し・`schemas/` への改名・`constants/` のドメイン分割は `docs/11-tasks.md` の改善候補として管理し、**新規追加分から上表に従う**。なお `lib/api/` を維持する間も、「`fetch` は API アクセス層のみ」「`lib/` の他のファイルは通信しない」は現時点から守る。
+
 ## ディレクトリ構成
 
 本プロジェクトは App Router 配下（`src/app/`）に実装一式を集約する。
@@ -65,12 +82,12 @@ apps/front/src/app/
 │   ├── auth/  blogs/  home/  common/  layout/
 ├── contexts/               # React Context（AuthContext, GlobalContext）
 ├── hooks/                  # クライアントロジック（useXxx）
-├── lib/api/                # API 通信関数
+├── lib/api/                # API アクセス（fetch はここだけ・移行目標: repositories/）
 ├── provider/               # QueryProvider / ToastProvider
-├── schema/                 # Zod スキーマ
+├── schema/                 # Zod スキーマ（移行目標: schemas/）
 ├── stores/                 # Zustand Store
 ├── types/                  # 型定義
-└── utils/const/            # 定数（constants.ts）
+└── utils/const/            # 定数（constants.ts・移行目標: constants/ へドメイン分割）
 ```
 
 ## インポート

--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -33,6 +33,16 @@ type OnSelectTag = (tag: string) => void;
 
 > **現状**: `types/blogs.ts` `types/users.ts` および各コンポーネントの props（`BlogCardProps` 等）は `interface` で定義されている。既存コードは即違反としない。`type` への統一は `docs/11-tasks.md` の改善候補として管理し、**新規追加分から `type` を使う**。
 
+## スキーマの配置（`schemas/` 集約）
+
+- Zod スキーマは**ソースルート直下の `schemas/` ディレクトリ**に集約する（本プロジェクトでは `apps/front/src/app/schemas/`）。
+- **`lib/validation.ts` のような単一ファイルにまとめない。** ディレクトリを切り、ドメイン単位でファイルを分ける（`schemas/blogs.ts` / `schemas/users.ts`）。`lib/` `utils/` の下に置かない（「関数の置き場」と分離する）。
+- **スキーマから導出した型は `types/` に再定義しない。** `z.infer<typeof blogSchema>` をスキーマファイルから `export` し、それを参照する（手書きの二重定義をしない）。
+- **検証を伴わない純粋な型は `schemas/` に置かない**（`types/` へ）。`schemas/` に置くのは「実行時に `parse` するもの」だけ。
+- barrel（`schemas/index.ts`）は作らない（理由は型・定数と同じ）。
+
+> **現状**: 本プロジェクトのスキーマは単数形の `apps/front/src/app/schema/`（`authSchema.ts` / `blogSchema.ts` / `blogCommentSchema.ts`）に置かれている。既存コードは即違反としない。複数形 `schemas/` への改名と、ファイル名からの `Schema` 接尾辞除去（`schemas/blogs.ts`）は `docs/11-tasks.md` の改善候補として管理する。
+
 ## 型定義の配置（コロケーション / `types/` 集約）
 
 型を各ファイルに散在させず、**参照範囲**で置き場所を決める。判断軸は「**その型を参照するファイルが 1 つに閉じるか**」。
@@ -41,6 +51,22 @@ type OnSelectTag = (tag: string) => void;
 |---|---|
 | **1 ファイルに閉じる** | その定義ファイル内にコロケーション（`export` しない） |
 | **2 ファイル以上** / レイヤ・機能をまたぐ | `types/` に集約して `export` |
+
+### 置き場所（ディレクトリを切る）
+
+- 集約先は**ソースルート直下の `types/` ディレクトリ**。本プロジェクトは実装一式を App Router 配下に集約しているため **`apps/front/src/app/types/`**（`@/app/types/*`）が該当する。
+- **単一ファイルにまとめない。** `lib/type.ts` のように 1 ファイルへ全型を詰め込む形は禁止。必ず**ディレクトリを切り、ドメイン単位でファイルを分ける**。
+- **`lib/` `utils/` の下に型ファイルを置かない。** `lib/` は「関数の置き場」、`types/` は「型の置き場」で分離する（定数も同様。「定数の配置」参照）。
+- 命名は**ディレクトリが複数形の `types`、ファイルはドメイン名**（`types/blogs.ts` / `types/users.ts`）。`type.ts` / `Types.ts` のような単数形・PascalCase のディレクトリ名は使わない。
+
+```
+apps/front/src/app/
+├── lib/            # 関数（API 通信・ユーティリティ）
+├── utils/const/    # 値（→ 移行目標: constants/）
+└── types/          # 型
+    ├── blogs.ts
+    └── users.ts
+```
 
 ### 運用ルール
 
@@ -78,6 +104,14 @@ export type Blog = { id: string; title: string; tags: string[]; likes: number };
 |---|---|
 | **1 ファイルに閉じる** | その定義ファイルの先頭で `const` 宣言（`export` しない） |
 | **2 ファイル以上** / レイヤ・機能をまたぐ | 共通定数へ集約して `export` |
+
+### 置き場所（ディレクトリを切る）
+
+型と同じ方針で置き場所を決める（詳細は「型定義の配置」の同名節）。
+
+- 集約先は**ソースルート直下の `constants/` ディレクトリ**（本プロジェクトでは `apps/front/src/app/constants/`）。
+- **単一ファイルにまとめない。** `utils/const/constants.ts` のように 1 ファイル・1 オブジェクトへ全定数を詰め込む形は禁止。**ディレクトリを切り、ドメイン単位でファイルを分ける**。
+- 命名は**ディレクトリが複数形の `constants`**（`constant.ts` のような単数形の単一ファイルにしない）。
 
 ### 運用ルール
 

--- a/docs/11-tasks.md
+++ b/docs/11-tasks.md
@@ -132,6 +132,8 @@
 - [ ] SSR / SSGの活用（現在は全ページCSR）
 - [ ] **定数配置の移行**（`.claude/rules/typescript.md`「定数の配置」の移行目標）: 現在は `utils/const/constants.ts` の `COMMON_CONSTANTS` 1 オブジェクトに全ドメインを集約し `as const` も未付与。ドメイン単位のファイル分割 + `as const` 付与へ段階移行する。`as const` を付けると `BLOG_LIST.POPULAR` 等がリテラル型に固定され、union の導出・補完が効くようになる
 - [ ] **型定義の `type` 統一**（`.claude/rules/typescript.md`「type vs interface」の移行目標）: `types/blogs.ts` `types/users.ts` と各コンポーネントの props（`BlogCardProps` 等）が `interface` で定義されている。class 契約・宣言マージのいずれにも該当しないため `type` へ寄せる。新規追加分は `type` を使う
+- [ ] **API アクセス層の `repositories/` 切り出し**（`.claude/rules/frontend.md`「関心別にディレクトリを切る」の移行目標）: 現在 API 通信関数は `lib/api/` に置かれている。`lib/` を「通信を持たない純粋ユーティリティ」に限定し、`fetch` を含む関数は `src/app/repositories/` へドメイン単位で移す
+- [ ] **スキーマディレクトリの複数形化**（`.claude/rules/typescript.md`「スキーマの配置」の移行目標）: 単数形 `schema/` + `xxxSchema.ts` 命名を `schemas/blogs.ts` `schemas/users.ts` のようにドメイン単位へ改名する。導出型は `z.infer` を各スキーマファイルから `export` し、`types/` に手書きで再定義しない
 - [ ] **状態・ロジック層のコメント拡充**（`.claude/rules/jsdoc.md`「状態・ロジック層のコメント」）: Zustand ストアの型（`AuthState` / `BlogState` / `CommentState`）と Context value の各メンバーにコメントが未付与。型メンバー単位で「いつ変わるか・空値の意味・副作用の有無」を補う
 - [ ] 画像アップロード機能
 - [ ] ブログ記事のOGP設定


### PR DESCRIPTION
## 概要

グローバルスキル管理リポジトリ `my-custom-skills` の PR #123 以降を調査し、本プロジェクトに該当する 2 件（#125 / #126・#127）を `.claude/rules/` へ取り込む。

## 取り込み内容

| 変更 | ファイル |
|---|---|
| 型・定数の「置き場所（ディレクトリを切る）」節（単一ファイル禁止・複数形命名・`lib/` に混ぜない） | `.claude/rules/typescript.md` |
| 「スキーマの配置（`schemas/` 集約）」節（`z.infer` を単一の真実に・`types/` へ再定義しない） | `.claude/rules/typescript.md` |
| 「関心別にディレクトリを切る」節（`types/` `constants/` `schemas/` `repositories/` `lib/` の責務表・`fetch` は API アクセス層のみ） | `.claude/rules/frontend.md` |
| 既存構成との差分を移行目標として登録 | `docs/11-tasks.md` |

いずれも既存ルールと同じく「**現状 → 移行目標**」注記を添え、既存コードを即違反としない形で追加している。

## スキップした PR と理由

- **#123**（DB 監査列の自動化 / prisma・gorm・jpa 等）: DB・ORM はバックエンド（Echo + Go）別リポジトリの管轄で、本リポジトリに該当ルールがない
- **#124 / #129 / #131 / #133**（Vercel デプロイ制御 `vercel.json`）: 本プロジェクトは GCP Cloud Run デプロイ（`terraform/` + `.github/workflows/deploy_to_googlecloud.yml`）で Vercel を使用していない

## ドキュメント影響

- `docs/11-tasks.md` を更新済み。
- `docs/09-architecture-specification.md` のディレクトリ構成は**更新不要**と判断した（実ディレクトリは変更しておらず、`repositories/` `schemas/` への移行は改善候補として `docs/11-tasks.md` で管理するため）。

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)